### PR TITLE
Update docs link in Installation/setup steps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Mac with Xcode and Android development tools is highly recommended. If you do 
 
 ## Installation/ setup steps
 
-(adapted from https://docs.expo.dev/get-started/installation/)
+(adapted from https://docs.expo.dev/get-started/create-a-project/)
 Bring your laptop! You will write code with it. If you regularly do JavaScript development, you likely have many of these installed on your machine already.
 
 ### Install Expo prerequisites


### PR DESCRIPTION
We no longer have the Installation guide page. Instead we a Create a project page where we document system requirements and command to create a new project: https://docs.expo.dev/get-started/create-a-project/.

This PR updates the link.